### PR TITLE
[Process Doc Update]: README for OctoAcme Project Management Docs (Project Management Processes Summary & Links to Process Docs)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# OctoAcme Project Management Docs
+
+This README serves as the central entry point for OctoAcme's project management documentation. It provides an overview of our project management philosophy, key workflows, defined roles, communication strategies, and quality assurance practices—plus direct links to the core process guides in this folder.
+
+---
+
+## OctoAcme Project Management Processes — Summary
+
+OctoAcme’s project management is built on structured, customer-centric workflows, rigorous communication, and strong ownership. Projects begin with clear problem validation and stakeholder alignment, followed by collaborative planning where deliverables are mapped, risks registered, and responsibilities assigned. Execution is tracked via project boards (with columns from Backlog to Done), regular standups, and milestone demos, enabling transparent progress monitoring.
+
+Roles are well-defined: Project Managers oversee delivery, scheduling, and risk; Product Managers keep outcomes customer-focused and prioritize backlogs; Developers design, build, test, and review work, collaborating with QA and stakeholders. Communication is deliberate—weekly syncs, frequent standups, and consistent status updates keep everyone aligned and enable prompt escalation of blockers.
+
+Quality assurance is embedded throughout, with automated CI pipelines for tests and lint, manual QA and security scans before releases, and strict definitions of done and acceptance criteria. Releases use a standardized checklist (backups, smoke tests, rollback plans) to reduce risk and improve observability. Retrospectives after each milestone or incident ensure lessons become actionable improvements.
+
+Centralized documentation and repeatable processes ensure every team member has equal, reliable access to knowledge—accelerating onboarding, reducing dependency risk, and making project delivery consistent and high-quality.
+
+---
+
+## Index of Core Process Documents
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](./octoacme-roles-and-personas.md)
+
+---
+
+To propose improvements or add content, use our [process doc update template](../.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml).


### PR DESCRIPTION
References issue [#2](https://github.com/rahulghosh8341/skills-scale-institutional-knowledge-using-copilot-spaces/issues/2)
Summarizes changes: Adds a central README to docs, includes an overview plus links to all key process docs.
Acceptance criteria covered: aligns with existing docs, improves clarity, closes an onboarding gap.